### PR TITLE
fix(lint): clean 31 pre-existing flake8 violations

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -49,3 +49,6 @@ bd.db
 # They would override fork protection in .git/info/exclude.
 # Config files (metadata.json, config.yaml) are tracked by git by default
 # since no pattern above ignores them.
+
+# Credential keys (machine-local secret material — never commit)
+.beads-credential-key

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -20,17 +20,14 @@ from dotenv import load_dotenv
 import redis
 
 # Add parent directory to path to import smart_router
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'scripts'))
-from smart_router import SmartRouter
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+from smart_router import SmartRouter  # noqa: E402
 
 # Load environment variables
 load_dotenv()
 
 # Configure logging
-logging.basicConfig(
-    level=os.getenv('LOG_LEVEL', 'INFO'),
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"), format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 # Initialize Flask app
@@ -38,9 +35,9 @@ app = Flask(__name__)
 CORS(app)
 
 # Initialize Redis for caching (optional)
-REDIS_HOST = os.getenv('REDIS_HOST', 'localhost')
-REDIS_PORT = int(os.getenv('REDIS_PORT', '6379'))
-CACHE_TTL_SECONDS = int(os.getenv('CACHE_TTL_SECONDS', '3600'))
+REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
+REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
+CACHE_TTL_SECONDS = int(os.getenv("CACHE_TTL_SECONDS", "3600"))
 MAX_PROMPT_LENGTH = 100_000
 
 try:
@@ -52,7 +49,7 @@ except Exception as e:
     redis_client = None
 
 # Rate limiting (3C)
-RATE_LIMIT = os.getenv('RATE_LIMIT', '60/minute')
+RATE_LIMIT = os.getenv("RATE_LIMIT", "60/minute")
 limiter = Limiter(
     get_remote_address,
     app=app,
@@ -62,31 +59,15 @@ limiter = Limiter(
 
 # Initialize Smart Router
 router = SmartRouter(
-    use_local=os.getenv('USE_LOCAL_FOR_SIMPLE', 'true').lower() == 'true',
-    complexity_threshold=float(os.getenv('COMPLEXITY_THRESHOLD', '0.5'))
+    use_local=os.getenv("USE_LOCAL_FOR_SIMPLE", "true").lower() == "true",
+    complexity_threshold=float(os.getenv("COMPLEXITY_THRESHOLD", "0.5")),
 )
 
 # Prometheus metrics
-REQUEST_COUNT = Counter(
-    'api_gateway_requests_total',
-    'Total requests to API gateway',
-    ['model', 'backend', 'status']
-)
-REQUEST_LATENCY = Histogram(
-    'api_gateway_request_duration_seconds',
-    'Request latency in seconds',
-    ['model', 'backend']
-)
-COST_TRACKER = Counter(
-    'api_gateway_cost_total',
-    'Total estimated cost in USD',
-    ['model']
-)
-CACHE_COUNTER = Counter(
-    'api_gateway_cache_total',
-    'Cache hit/miss counts',
-    ['result']
-)
+REQUEST_COUNT = Counter("api_gateway_requests_total", "Total requests to API gateway", ["model", "backend", "status"])
+REQUEST_LATENCY = Histogram("api_gateway_request_duration_seconds", "Request latency in seconds", ["model", "backend"])
+COST_TRACKER = Counter("api_gateway_cost_total", "Total estimated cost in USD", ["model"])
+CACHE_COUNTER = Counter("api_gateway_cache_total", "Cache hit/miss counts", ["result"])
 
 
 def _cache_key(prompt: str, model: str) -> str:
@@ -95,55 +76,58 @@ def _cache_key(prompt: str, model: str) -> str:
     return f"cache:{hashlib.sha256(raw.encode()).hexdigest()}"
 
 
-@app.route('/')
+@app.route("/")
 def index():
     """Health check endpoint"""
-    return jsonify({
-        'service': 'Hybrid AI Stack - API Gateway',
-        'status': 'healthy',
-        'version': '1.1.0',
-        'timestamp': datetime.utcnow().isoformat()
-    })
+    return jsonify(
+        {
+            "service": "Hybrid AI Stack - API Gateway",
+            "status": "healthy",
+            "version": "1.1.0",
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+    )
 
 
-@app.route('/health')
+@app.route("/health")
 @limiter.exempt
 def health():
     """Detailed health check"""
     health_status = {
-        'api_gateway': 'healthy',
-        'redis': 'healthy' if redis_client else 'unavailable',
-        'router': 'initialized',
-        'timestamp': datetime.utcnow().isoformat()
+        "api_gateway": "healthy",
+        "redis": "healthy" if redis_client else "unavailable",
+        "router": "initialized",
+        "timestamp": datetime.utcnow().isoformat(),
     }
 
     # Check Ollama connectivity and model availability
     try:
         import requests as req
-        ollama_url = os.getenv('OLLAMA_URL', 'http://localhost:11434')
+
+        ollama_url = os.getenv("OLLAMA_URL", "http://localhost:11434")
         response = req.get(f"{ollama_url}/api/tags", timeout=2)
         if response.status_code == 200:
             data = response.json()
-            pulled = {m['name'].split(':')[0] for m in data.get('models', [])}
-            required = {'tinyllama', 'phi'}
+            pulled = {m["name"].split(":")[0] for m in data.get("models", [])}
+            required = {"tinyllama", "phi"}
             missing = required - pulled
             if missing:
-                health_status['ollama'] = 'degraded'
-                health_status['ollama_missing_models'] = sorted(missing)
+                health_status["ollama"] = "degraded"
+                health_status["ollama_missing_models"] = sorted(missing)
             else:
-                health_status['ollama'] = 'healthy'
+                health_status["ollama"] = "healthy"
         else:
-            health_status['ollama'] = 'error'
+            health_status["ollama"] = "error"
     except Exception:
-        health_status['ollama'] = 'unavailable'
+        health_status["ollama"] = "unavailable"
 
     # Check Claude API key
-    health_status['claude_api'] = 'configured' if os.getenv('ANTHROPIC_API_KEY') else 'not configured'
+    health_status["claude_api"] = "configured" if os.getenv("ANTHROPIC_API_KEY") else "not configured"
 
     return jsonify(health_status)
 
 
-@app.route('/api/v1/chat', methods=['POST'])
+@app.route("/api/v1/chat", methods=["POST"])
 def chat():
     """
     Main chat endpoint - routes request through smart router
@@ -157,17 +141,17 @@ def chat():
     try:
         data = request.get_json(silent=True)
 
-        if not data or 'prompt' not in data:
-            return jsonify({'error': 'Missing prompt in request body'}), 400
+        if not data or "prompt" not in data:
+            return jsonify({"error": "Missing prompt in request body"}), 400
 
-        prompt = data['prompt']
+        prompt = data["prompt"]
 
         # Validate prompt length (3C)
         if len(prompt) > MAX_PROMPT_LENGTH:
-            return jsonify({'error': f'Prompt exceeds maximum length of {MAX_PROMPT_LENGTH} characters'}), 413
+            return jsonify({"error": f"Prompt exceeds maximum length of {MAX_PROMPT_LENGTH} characters"}), 413
 
-        model_override = data.get('model', 'auto')
-        no_cache = request.headers.get('Cache-Control') == 'no-cache'
+        model_override = data.get("model", "auto")
+        no_cache = request.headers.get("Cache-Control") == "no-cache"
 
         logger.info(f"Received chat request: {prompt[:50]}...")
 
@@ -176,36 +160,36 @@ def chat():
         if redis_client and not no_cache:
             cached = redis_client.get(cache_key)
             if cached:
-                CACHE_COUNTER.labels(result='hit').inc()
+                CACHE_COUNTER.labels(result="hit").inc()
                 result = json.loads(cached)
-                result['cached'] = True
+                result["cached"] = True
                 return jsonify(result), 200
 
-        CACHE_COUNTER.labels(result='miss').inc()
+        CACHE_COUNTER.labels(result="miss").inc()
 
         start_time = time.time()
 
-        if model_override != 'auto':
+        if model_override != "auto":
             # Direct model selection via MODELS config
             model_config = router.MODELS.get(model_override)
             if not model_config:
-                return jsonify({'error': f'Unknown model: {model_override}'}), 400
+                return jsonify({"error": f"Unknown model: {model_override}"}), 400
 
-            backend = model_config['backend']
-            if backend == 'local':
+            backend = model_config["backend"]
+            if backend == "local":
                 result = router.execute_ollama_request(model_override, prompt)
-            elif backend == 'ternary':
+            elif backend == "ternary":
                 result = router.execute_ternary_request(model_override, prompt)
-            elif backend == 'cloud':
+            elif backend == "cloud":
                 result = router.execute_claude_request(prompt)
             else:
-                return jsonify({'error': f'Unknown backend: {backend}'}), 400
+                return jsonify({"error": f"Unknown backend: {backend}"}), 400
 
             # Add routing metadata
-            result['routing'] = {
-                'complexity': 0,
-                'reasoning': f'Manual model selection: {model_override}',
-                'estimated_cost': result.get('cost', 0)
+            result["routing"] = {
+                "complexity": 0,
+                "reasoning": f"Manual model selection: {model_override}",
+                "estimated_cost": result.get("cost", 0),
             }
         else:
             # Smart routing
@@ -213,15 +197,15 @@ def chat():
 
         # Calculate latency
         latency = time.time() - start_time
-        result['latency_seconds'] = latency
-        result['cached'] = False
+        result["latency_seconds"] = latency
+        result["cached"] = False
 
         # Update Prometheus metrics
-        model = result['model']
-        backend = result['backend']
-        REQUEST_COUNT.labels(model=model, backend=backend, status='success').inc()
+        model = result["model"]
+        backend = result["backend"]
+        REQUEST_COUNT.labels(model=model, backend=backend, status="success").inc()
         REQUEST_LATENCY.labels(model=model, backend=backend).observe(latency)
-        COST_TRACKER.labels(model=model).inc(result.get('cost', 0))
+        COST_TRACKER.labels(model=model).inc(result.get("cost", 0))
 
         logger.info(f"Request processed: model={model}, latency={latency:.2f}s, cost=${result.get('cost', 0):.6f}")
 
@@ -236,11 +220,11 @@ def chat():
 
     except Exception as e:
         logger.error(f"Chat request failed: {e}", exc_info=True)
-        REQUEST_COUNT.labels(model='unknown', backend='unknown', status='error').inc()
-        return jsonify({'error': str(e)}), 500
+        REQUEST_COUNT.labels(model="unknown", backend="unknown", status="error").inc()
+        return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/v1/complexity', methods=['POST'])
+@app.route("/api/v1/complexity", methods=["POST"])
 def estimate_complexity():
     """
     Estimate prompt complexity without executing it
@@ -253,29 +237,31 @@ def estimate_complexity():
     try:
         data = request.get_json(silent=True)
 
-        if not data or 'prompt' not in data:
-            return jsonify({'error': 'Missing prompt in request body'}), 400
+        if not data or "prompt" not in data:
+            return jsonify({"error": "Missing prompt in request body"}), 400
 
-        prompt = data['prompt']
+        prompt = data["prompt"]
 
         # Get complexity estimate
         complexity, reasoning = router.estimate_complexity(prompt)
         selected_model = router.select_model(complexity)
 
-        return jsonify({
-            'complexity': complexity,
-            'reasoning': reasoning,
-            'recommended_model': selected_model,
-            'backend': router.MODELS[selected_model]['backend'],
-            'estimated_cost': router.estimate_cost(prompt, selected_model)
-        }), 200
+        return jsonify(
+            {
+                "complexity": complexity,
+                "reasoning": reasoning,
+                "recommended_model": selected_model,
+                "backend": router.MODELS[selected_model]["backend"],
+                "estimated_cost": router.estimate_cost(prompt, selected_model),
+            }
+        ), 200
 
     except Exception as e:
         logger.error(f"Complexity estimation failed: {e}")
-        return jsonify({'error': str(e)}), 500
+        return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/v1/models', methods=['GET'])
+@app.route("/api/v1/models", methods=["GET"])
 def list_models():
     """List available models with status (3B)"""
     try:
@@ -284,56 +270,56 @@ def list_models():
         # Check Ollama models
         ollama_models = set()
         try:
-            ollama_url = os.getenv('OLLAMA_URL', 'http://localhost:11434')
+            ollama_url = os.getenv("OLLAMA_URL", "http://localhost:11434")
             response = req.get(f"{ollama_url}/api/tags", timeout=2)
             if response.status_code == 200:
-                ollama_models = {
-                    m['name'].split(':')[0] for m in response.json().get('models', [])
-                }
+                ollama_models = {m["name"].split(":")[0] for m in response.json().get("models", [])}
         except Exception:
             pass
 
         # Check ternary health
         ternary_ok = False
         try:
-            ternary_url = os.getenv('TERNARY_URL', 'http://localhost:8003')
+            ternary_url = os.getenv("TERNARY_URL", "http://localhost:8003")
             resp = req.get(f"{ternary_url}/health", timeout=2)
             ternary_ok = resp.status_code == 200
         except Exception:
             pass
 
-        has_claude_key = bool(os.getenv('ANTHROPIC_API_KEY'))
+        has_claude_key = bool(os.getenv("ANTHROPIC_API_KEY"))
 
         # Map our model names to Ollama names for availability check
-        ollama_name_map = {'tinyllama': 'tinyllama', 'phi2': 'phi'}
+        ollama_name_map = {"tinyllama": "tinyllama", "phi2": "phi"}
 
         models = []
         for name, config in router.MODELS.items():
-            backend = config['backend']
-            if backend == 'local':
+            backend = config["backend"]
+            if backend == "local":
                 available = ollama_name_map.get(name, name) in ollama_models
-            elif backend == 'ternary':
+            elif backend == "ternary":
                 available = ternary_ok
-            elif backend == 'cloud':
+            elif backend == "cloud":
                 available = has_claude_key
             else:
                 available = False
 
-            models.append({
-                'name': name,
-                'backend': backend,
-                'available': available,
-                'cost_per_token': config.get('cost_per_token', 0.0),
-                'max_complexity': config.get('max_complexity', 1.0),
-            })
+            models.append(
+                {
+                    "name": name,
+                    "backend": backend,
+                    "available": available,
+                    "cost_per_token": config.get("cost_per_token", 0.0),
+                    "max_complexity": config.get("max_complexity", 1.0),
+                }
+            )
 
-        return jsonify({'models': models}), 200
+        return jsonify({"models": models}), 200
     except Exception as e:
         logger.error(f"Model listing failed: {e}")
-        return jsonify({'error': str(e)}), 500
+        return jsonify({"error": str(e)}), 500
 
 
-@app.route('/api/v1/stats', methods=['GET'])
+@app.route("/api/v1/stats", methods=["GET"])
 def get_stats():
     """Get routing statistics"""
     try:
@@ -341,19 +327,19 @@ def get_stats():
         return jsonify(stats), 200
     except Exception as e:
         logger.error(f"Stats retrieval failed: {e}")
-        return jsonify({'error': str(e)}), 500
+        return jsonify({"error": str(e)}), 500
 
 
-@app.route('/metrics')
+@app.route("/metrics")
 @limiter.exempt
 def metrics():
     """Prometheus metrics endpoint"""
-    return generate_latest(), 200, {'Content-Type': CONTENT_TYPE_LATEST}
+    return generate_latest(), 200, {"Content-Type": CONTENT_TYPE_LATEST}
 
 
-if __name__ == '__main__':
-    port = int(os.getenv('GATEWAY_PORT', '8080'))
-    host = os.getenv('GATEWAY_HOST', '0.0.0.0')
+if __name__ == "__main__":
+    port = int(os.getenv("GATEWAY_PORT", "8080"))
+    host = os.getenv("GATEWAY_HOST", "0.0.0.0")
 
     logger.info(f"Starting API Gateway on {host}:{port}")
     app.run(host=host, port=port, debug=False)

--- a/scripts/benchmark_ternary.py
+++ b/scripts/benchmark_ternary.py
@@ -7,13 +7,14 @@ Measures inference speed, latency, and cost comparison
 import requests
 import time
 import statistics
-from typing import Dict, List
+from typing import List
 from dataclasses import dataclass
-import json
+
 
 @dataclass
 class BenchmarkResult:
     """Results from a single benchmark"""
+
     model: str
     prompt: str
     time_seconds: float
@@ -21,49 +22,47 @@ class BenchmarkResult:
     success: bool
     error: str = ""
 
+
 # Test prompts covering different complexity levels
 TEST_PROMPTS = {
-    'simple': [
+    "simple": [
         "What is the capital of France?",
         "What is 2+2?",
         "Define 'algorithm'",
     ],
-    'medium': [
+    "medium": [
         "Explain quantum computing in simple terms.",
         "What are the key differences between Python and JavaScript?",
         "Describe the HTTP request-response cycle.",
     ],
-    'complex': [
+    "complex": [
         "Write a Python function to implement quicksort with detailed comments.",
         "Explain the difference between REST and GraphQL with code examples.",
         "Design a microservices architecture for an e-commerce platform.",
-    ]
+    ],
 }
+
 
 def benchmark_model(endpoint: str, model: str, prompt: str, timeout: int = 60) -> BenchmarkResult:
     """Benchmark a single request"""
     start = time.time()
 
     try:
-        response = requests.post(
-            endpoint,
-            json={"prompt": prompt, "model": model, "max_tokens": 200},
-            timeout=timeout
-        )
+        response = requests.post(endpoint, json={"prompt": prompt, "model": model, "max_tokens": 200}, timeout=timeout)
 
         elapsed = time.time() - start
 
         if response.status_code == 200:
             data = response.json()
             # Try to extract tokens/s from response
-            tokens_per_second = data.get('tokens_per_second', 200 / elapsed if elapsed > 0 else 0)
+            tokens_per_second = data.get("tokens_per_second", 200 / elapsed if elapsed > 0 else 0)
 
             return BenchmarkResult(
                 model=model,
                 prompt=prompt[:50] + "...",
                 time_seconds=elapsed,
                 tokens_per_second=tokens_per_second,
-                success=True
+                success=True,
             )
         else:
             return BenchmarkResult(
@@ -72,7 +71,7 @@ def benchmark_model(endpoint: str, model: str, prompt: str, timeout: int = 60) -
                 time_seconds=elapsed,
                 tokens_per_second=0,
                 success=False,
-                error=f"HTTP {response.status_code}"
+                error=f"HTTP {response.status_code}",
             )
 
     except Exception as e:
@@ -83,8 +82,9 @@ def benchmark_model(endpoint: str, model: str, prompt: str, timeout: int = 60) -
             time_seconds=elapsed,
             tokens_per_second=0,
             success=False,
-            error=str(e)
+            error=str(e),
         )
+
 
 def run_benchmarks():
     """Run comprehensive benchmark suite"""
@@ -95,28 +95,28 @@ def run_benchmarks():
     # Model configurations
     models_to_test = [
         {
-            'name': 'TinyLlama (Standard)',
-            'endpoint': 'http://localhost:11434/api/generate',
-            'model_id': 'tinyllama',
-            'backend': 'ollama'
+            "name": "TinyLlama (Standard)",
+            "endpoint": "http://localhost:11434/api/generate",
+            "model_id": "tinyllama",
+            "backend": "ollama",
         },
         {
-            'name': 'Phi-2 (Standard)',
-            'endpoint': 'http://localhost:11434/api/generate',
-            'model_id': 'phi',
-            'backend': 'ollama'
+            "name": "Phi-2 (Standard)",
+            "endpoint": "http://localhost:11434/api/generate",
+            "model_id": "phi",
+            "backend": "ollama",
         },
         {
-            'name': 'BitNet 2B (Ternary)',
-            'endpoint': 'http://localhost:8003/generate',
-            'model_id': 'bitnet-2b',
-            'backend': 'ternary'
+            "name": "BitNet 2B (Ternary)",
+            "endpoint": "http://localhost:8003/generate",
+            "model_id": "bitnet-2b",
+            "backend": "ternary",
         },
         {
-            'name': 'Mistral-7B (Ternary)',
-            'endpoint': 'http://localhost:8003/generate',
-            'model_id': 'mistral-7b-ternary',
-            'backend': 'ternary'
+            "name": "Mistral-7B (Ternary)",
+            "endpoint": "http://localhost:8003/generate",
+            "model_id": "mistral-7b-ternary",
+            "backend": "ternary",
         },
     ]
 
@@ -130,16 +130,14 @@ def run_benchmarks():
             print(f"\n  Prompt: {prompt[:60]}...")
 
             for model_config in models_to_test:
-                result = benchmark_model(
-                    model_config['endpoint'],
-                    model_config['model_id'],
-                    prompt
-                )
+                result = benchmark_model(model_config["endpoint"], model_config["model_id"], prompt)
 
                 all_results.append(result)
 
                 if result.success:
-                    print(f"    ✅ {model_config['name']:30s}: {result.time_seconds:5.2f}s ({result.tokens_per_second:5.1f} tok/s)")
+                    print(
+                        f"    ✅ {model_config['name']:30s}: {result.time_seconds:5.2f}s ({result.tokens_per_second:5.1f} tok/s)"  # noqa: E501
+                    )
                 else:
                     print(f"    ❌ {model_config['name']:30s}: FAILED - {result.error}")
 
@@ -151,14 +149,16 @@ def run_benchmarks():
     print("")
 
     for model_config in models_to_test:
-        model_results = [r for r in all_results if r.model == model_config['model_id'] and r.success]
+        model_results = [r for r in all_results if r.model == model_config["model_id"] and r.success]
 
         if model_results:
             times = [r.time_seconds for r in model_results]
             tps = [r.tokens_per_second for r in model_results]
 
             print(f"\n{model_config['name']}:")
-            print(f"  Success rate: {len(model_results)}/{len(all_results) // len(models_to_test)} ({len(model_results) / (len(all_results) // len(models_to_test)) * 100:.1f}%)")
+            print(
+                f"  Success rate: {len(model_results)}/{len(all_results) // len(models_to_test)} ({len(model_results) / (len(all_results) // len(models_to_test)) * 100:.1f}%)"  # noqa: E501
+            )
             print(f"  Avg time:     {statistics.mean(times):.2f}s (min: {min(times):.2f}s, max: {max(times):.2f}s)")
             print(f"  Avg tok/s:    {statistics.mean(tps):.1f} (min: {min(tps):.1f}, max: {max(tps):.1f})")
             print(f"  Median time:  {statistics.median(times):.2f}s")
@@ -172,28 +172,28 @@ def run_benchmarks():
     print("=" * 70)
 
     # Compare BitNet 2B vs Phi-2 (similar parameter count)
-    bitnet_results = [r for r in all_results if r.model == 'bitnet-2b' and r.success]
-    phi_results = [r for r in all_results if r.model == 'phi' and r.success]
+    bitnet_results = [r for r in all_results if r.model == "bitnet-2b" and r.success]
+    phi_results = [r for r in all_results if r.model == "phi" and r.success]
 
     if bitnet_results and phi_results:
         bitnet_avg_time = statistics.mean([r.time_seconds for r in bitnet_results])
         phi_avg_time = statistics.mean([r.time_seconds for r in phi_results])
         speedup = phi_avg_time / bitnet_avg_time if bitnet_avg_time > 0 else 0
 
-        print(f"\nBitNet 2B vs Phi-2 (2.7B):")
+        print("\nBitNet 2B vs Phi-2 (2.7B):")
         print(f"  BitNet avg: {bitnet_avg_time:.2f}s")
         print(f"  Phi-2 avg:  {phi_avg_time:.2f}s")
         print(f"  Speedup:    {speedup:.2f}x {'FASTER' if speedup > 1 else 'SLOWER'}")
 
     # Compare Mistral-7B ternary vs standard (if available)
-    mistral_ternary_results = [r for r in all_results if r.model == 'mistral-7b-ternary' and r.success]
-    tinyllama_results = [r for r in all_results if r.model == 'tinyllama' and r.success]
+    mistral_ternary_results = [r for r in all_results if r.model == "mistral-7b-ternary" and r.success]
+    tinyllama_results = [r for r in all_results if r.model == "tinyllama" and r.success]
 
     if mistral_ternary_results and tinyllama_results:
         mistral_avg_time = statistics.mean([r.time_seconds for r in mistral_ternary_results])
         tiny_avg_time = statistics.mean([r.time_seconds for r in tinyllama_results])
 
-        print(f"\nMistral-7B (Ternary) vs TinyLlama:")
+        print("\nMistral-7B (Ternary) vs TinyLlama:")
         print(f"  Mistral-7B ternary: {mistral_avg_time:.2f}s (better quality, larger model)")
         print(f"  TinyLlama:          {tiny_avg_time:.2f}s")
 
@@ -205,6 +205,7 @@ def run_benchmarks():
     print("  - 82% energy reduction compared to FP16 models")
     print("  - Run 7B models on 8GB RAM (vs 28GB standard)")
     print("=" * 70)
+
 
 if __name__ == "__main__":
     try:

--- a/scripts/moderation_pipeline.py
+++ b/scripts/moderation_pipeline.py
@@ -129,7 +129,7 @@ Be thorough and explain your reasoning.
         print("CONTENT MODERATION SUMMARY")
         print("=" * 60)
         print(f"Total Posts Processed: {summary['total_processed']}")
-        print(f"   Safe (local):      {summary['local_safe']}")
+        print(f"    Safe (local):      {summary['local_safe']}")
         print(f"    Flagged (cloud):   {summary['cloud_reviewed']}")
         print()
         print("COST COMPARISON:")
@@ -186,7 +186,7 @@ def demo():
     print("    50 flagged (cloud) = $0.75")
     print("    Total = $0.75")
     print()
-    print("  = deg Savings: $14.25 (95% reduction)")
+    print("  ~ Savings: $14.25 (95% reduction)")
     print("=" * 60)
 
 

--- a/scripts/moderation_pipeline.py
+++ b/scripts/moderation_pipeline.py
@@ -6,7 +6,7 @@ Demonstrates how using local models for initial classification can reduce costs
 by 90%+ compared to cloud-only approaches.
 
 Cost Comparison:
-- Cloud Only:  1000 posts × $0.015/analysis = $15.00
+- Cloud Only:  1000 posts x $0.015/analysis = $15.00
 - Hybrid:      950 safe (local) + 50 flagged (cloud) = $0.75
   Savings: $14.25 (95% reduction)
 """
@@ -17,7 +17,8 @@ from typing import Dict, Tuple
 
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from smart_router import SmartRouter
+from smart_router import SmartRouter  # noqa: E402
+
 
 class ContentModerator:
     """
@@ -28,12 +29,7 @@ class ContentModerator:
 
     def __init__(self):
         self.router = SmartRouter()
-        self.stats = {
-            'total_processed': 0,
-            'local_safe': 0,
-            'cloud_reviewed': 0,
-            'total_cost': 0.0
-        }
+        self.stats = {"total_processed": 0, "local_safe": 0, "cloud_reviewed": 0, "total_cost": 0.0}
 
     def classify_content(self, content: str) -> Tuple[str, str, float]:
         """
@@ -47,9 +43,9 @@ Content: {content}
 Respond with ONLY one word: SAFE or FLAGGED
 """
         # Force TinyLlama for fast classification
-        result = self.router.execute_ollama_request('tinyllama', prompt)
+        result = self.router.execute_ollama_request("tinyllama", prompt)
 
-        classification = result['response'].strip().upper()
+        classification = result["response"].strip().upper()
         return classification, "Fast local classification", 0.0
 
     def deep_review(self, content: str) -> Dict:
@@ -70,81 +66,77 @@ Be thorough and explain your reasoning.
 """
         result = self.router.execute_claude_request(prompt)
 
-        self.stats['total_cost'] += result.get('cost', 0)
+        self.stats["total_cost"] += result.get("cost", 0)
 
-        return {
-            'review': result['response'],
-            'cost': result.get('cost', 0),
-            'model': 'claude-sonnet'
-        }
+        return {"review": result["response"], "cost": result.get("cost", 0), "model": "claude-sonnet"}
 
     def moderate(self, content: str) -> Dict:
         """
         Full moderation pipeline
         """
-        self.stats['total_processed'] += 1
+        self.stats["total_processed"] += 1
 
         # Stage 1: Quick local classification
         classification, reasoning, cost = self.classify_content(content)
 
-        if 'SAFE' in classification:
+        if "SAFE" in classification:
             # Content appears safe - no need for expensive review
-            self.stats['local_safe'] += 1
+            self.stats["local_safe"] += 1
             return {
-                'status': 'approved',
-                'stage': 'local_classification',
-                'cost': cost,
-                'reasoning': 'Passed initial safety check'
+                "status": "approved",
+                "stage": "local_classification",
+                "cost": cost,
+                "reasoning": "Passed initial safety check",
             }
         else:
             # Flagged content - requires detailed review
-            self.stats['cloud_reviewed'] += 1
+            self.stats["cloud_reviewed"] += 1
             review = self.deep_review(content)
 
             return {
-                'status': 'needs_review',
-                'stage': 'cloud_review',
-                'cost': review['cost'],
-                'review': review['review']
+                "status": "needs_review",
+                "stage": "cloud_review",
+                "cost": review["cost"],
+                "review": review["review"],
             }
 
     def get_cost_savings(self) -> Dict:
         """Calculate cost savings vs cloud-only approach"""
         # Cloud-only cost: all requests to Claude
-        cloud_only_cost = self.stats['total_processed'] * 0.015
+        cloud_only_cost = self.stats["total_processed"] * 0.015
 
         # Hybrid cost: only flagged content to Claude
-        hybrid_cost = self.stats['total_cost']
+        hybrid_cost = self.stats["total_cost"]
 
         savings = cloud_only_cost - hybrid_cost
         savings_pct = (savings / cloud_only_cost * 100) if cloud_only_cost > 0 else 0
 
         return {
-            'total_processed': self.stats['total_processed'],
-            'local_safe': self.stats['local_safe'],
-            'cloud_reviewed': self.stats['cloud_reviewed'],
-            'cloud_only_cost': cloud_only_cost,
-            'hybrid_cost': hybrid_cost,
-            'savings': savings,
-            'savings_percent': savings_pct
+            "total_processed": self.stats["total_processed"],
+            "local_safe": self.stats["local_safe"],
+            "cloud_reviewed": self.stats["cloud_reviewed"],
+            "cloud_only_cost": cloud_only_cost,
+            "hybrid_cost": hybrid_cost,
+            "savings": savings,
+            "savings_percent": savings_pct,
         }
 
     def print_summary(self):
         """Print moderation summary"""
         summary = self.get_cost_savings()
 
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("CONTENT MODERATION SUMMARY")
-        print("="*60)
+        print("=" * 60)
         print(f"Total Posts Processed: {summary['total_processed']}")
         print(f"   Safe (local):      {summary['local_safe']}")
-        print(f"    Flagged (cloud):   {summary['cloud_reviewed']}")
+        print(f"    Flagged (cloud):   {summary['cloud_reviewed']}")
         print()
         print("COST COMPARISON:")
         print(f"  Cloud Only:  ${summary['cloud_only_cost']:.4f}")
         print(f"  Hybrid:      ${summary['hybrid_cost']:.4f}")
         print(f"  Savings:     ${summary['savings']:.4f} ({summary['savings_percent']:.1f}%)")
-        print("="*60 + "\n")
+        print("=" * 60 + "\n")
 
 
 def demo():
@@ -164,7 +156,7 @@ def demo():
     ]
 
     print("\nContent Moderation Pipeline Demo")
-    print("="*60)
+    print("=" * 60)
 
     for i, content in enumerate(test_content, 1):
         print(f"\n[{i}/{len(test_content)}] Processing: {content[:50]}...")
@@ -175,8 +167,8 @@ def demo():
         print(f"  Stage: {result['stage']}")
         print(f"  Cost: ${result['cost']:.6f}")
 
-        if result['status'] == 'needs_review':
-            print(f"  Review Required!")
+        if result["status"] == "needs_review":
+            print("  Review Required!")
 
     # Print final summary
     moderator.print_summary()
@@ -187,16 +179,16 @@ def demo():
     print("Assuming 95% safe content, 5% flagged:")
     print()
     print("  Cloud Only Approach:")
-    print("    1000 posts × $0.015 = $15.00")
+    print("    1000 posts x $0.015 = $15.00")
     print()
     print("  Hybrid Approach:")
     print("    950 safe (local) =  $0.00")
     print("    50 flagged (cloud) = $0.75")
     print("    Total = $0.75")
     print()
-    print("  =° Savings: $14.25 (95% reduction)")
-    print("="*60)
+    print("  = deg Savings: $14.25 (95% reduction)")
+    print("=" * 60)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     demo()

--- a/scripts/smart_router.py
+++ b/scripts/smart_router.py
@@ -9,7 +9,6 @@ import re
 import json
 import logging
 import subprocess
-from datetime import datetime
 from typing import Dict, Tuple
 from dataclasses import dataclass
 import requests
@@ -17,6 +16,7 @@ from anthropic import Anthropic
 
 try:
     import tiktoken
+
     _tiktoken_encoding = tiktoken.get_encoding("cl100k_base")
 except ImportError:
     _tiktoken_encoding = None
@@ -25,74 +25,97 @@ except ImportError:
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 @dataclass
 class RoutingDecision:
     """Routing decision with metadata"""
+
     model: str
     complexity: float
     estimated_cost: float
     reasoning: str
     backend: str  # 'local' or 'cloud'
 
+
 class SmartRouter:
     """Intelligent router for AI requests"""
 
     # Model configurations
     MODELS = {
-        'tinyllama': {
-            'backend': 'local',
-            'max_complexity': 0.3,
-            'cost_per_token': 0.0,  # Free (local)
-            'endpoint': 'http://localhost:11434/api/generate'
+        "tinyllama": {
+            "backend": "local",
+            "max_complexity": 0.3,
+            "cost_per_token": 0.0,  # Free (local)
+            "endpoint": "http://localhost:11434/api/generate",
         },
-        'phi2': {
-            'backend': 'local',
-            'max_complexity': 0.6,
-            'cost_per_token': 0.0,  # Free (local)
-            'endpoint': 'http://localhost:11434/api/generate'
+        "phi2": {
+            "backend": "local",
+            "max_complexity": 0.6,
+            "cost_per_token": 0.0,  # Free (local)
+            "endpoint": "http://localhost:11434/api/generate",
         },
         # NEW: Ternary models (BitNet 1.58-bit)
-        'bitnet-2b': {
-            'backend': 'ternary',
-            'max_complexity': 0.5,
-            'cost_per_token': 0.0,  # Free (local)
-            'endpoint': 'http://localhost:8003/generate',
-            'speed_multiplier': 6.0,  # 6x faster than standard
-            'energy_savings': 0.82  # 82% energy reduction
+        "bitnet-2b": {
+            "backend": "ternary",
+            "max_complexity": 0.5,
+            "cost_per_token": 0.0,  # Free (local)
+            "endpoint": "http://localhost:8003/generate",
+            "speed_multiplier": 6.0,  # 6x faster than standard
+            "energy_savings": 0.82,  # 82% energy reduction
         },
-        'mistral-7b-ternary': {
-            'backend': 'ternary',
-            'max_complexity': 0.8,
-            'cost_per_token': 0.0,  # Free (local)
-            'endpoint': 'http://localhost:8003/generate',
-            'speed_multiplier': 6.0,
-            'energy_savings': 0.82
+        "mistral-7b-ternary": {
+            "backend": "ternary",
+            "max_complexity": 0.8,
+            "cost_per_token": 0.0,  # Free (local)
+            "endpoint": "http://localhost:8003/generate",
+            "speed_multiplier": 6.0,
+            "energy_savings": 0.82,
         },
-        'claude-sonnet': {
-            'backend': 'cloud',
-            'max_complexity': 1.0,
-            'cost_per_1m_tokens': 3.0,  # $3 per 1M tokens
-            'cost_per_token': 0.000003
-        }
+        "claude-sonnet": {
+            "backend": "cloud",
+            "max_complexity": 1.0,
+            "cost_per_1m_tokens": 3.0,  # $3 per 1M tokens
+            "cost_per_token": 0.000003,
+        },
     }
 
     # Complexity keywords
     COMPLEX_KEYWORDS = [
-        'analyze', 'design', 'architect', 'implement', 'refactor',
-        'optimize', 'debug', 'explain in detail', 'comprehensive',
-        'write code', 'create function', 'build', 'develop'
+        "analyze",
+        "design",
+        "architect",
+        "implement",
+        "refactor",
+        "optimize",
+        "debug",
+        "explain in detail",
+        "comprehensive",
+        "write code",
+        "create function",
+        "build",
+        "develop",
     ]
 
     SIMPLE_KEYWORDS = [
-        'summarize', 'list', 'what is', 'define', 'yes or no',
-        'classify', 'categorize', 'is this', 'true or false'
+        "summarize",
+        "list",
+        "what is",
+        "define",
+        "yes or no",
+        "classify",
+        "categorize",
+        "is this",
+        "true or false",
     ]
 
     CODE_PATTERNS = [
-        r'```',  # Code blocks
-        r'\bdef\b', r'\bclass\b', r'\bfunction\b',  # Function/class definitions
-        r'\bimport\b', r'\bfrom\b',  # Imports
-        r'[{}\[\]();]',  # Code-like syntax
+        r"```",  # Code blocks
+        r"\bdef\b",
+        r"\bclass\b",
+        r"\bfunction\b",  # Function/class definitions
+        r"\bimport\b",
+        r"\bfrom\b",  # Imports
+        r"[{}\[\]();]",  # Code-like syntax
     ]
 
     def __init__(self, use_local: bool = True, complexity_threshold: float = 0.5, use_ternary: bool = True):
@@ -102,8 +125,8 @@ class SmartRouter:
         self.use_ternary = use_ternary
         self.ternary_available = False
         self.anthropic_client = None
-        self.claude_model = os.getenv('CLAUDE_MODEL', 'claude-sonnet-4-20250514')
-        self.taskwarrior_enabled = os.getenv('ENABLE_TASKWARRIOR_LOGGING', 'false').lower() == 'true'
+        self.claude_model = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+        self.taskwarrior_enabled = os.getenv("ENABLE_TASKWARRIOR_LOGGING", "false").lower() == "true"
 
         # Check if ternary runtime is available
         if self.use_ternary:
@@ -114,7 +137,7 @@ class SmartRouter:
                 logger.info("Ternary runtime not available, using standard models")
 
         # Initialize Anthropic client if API key available
-        api_key = os.getenv('ANTHROPIC_API_KEY')
+        api_key = os.getenv("ANTHROPIC_API_KEY")
         if api_key:
             self.anthropic_client = Anthropic(api_key=api_key)
         else:
@@ -123,13 +146,13 @@ class SmartRouter:
     def _check_ternary_available(self) -> bool:
         """Check if ternary runtime is installed and running"""
         try:
-            ternary_url = os.getenv('TERNARY_URL', 'http://localhost:8003')
+            ternary_url = os.getenv("TERNARY_URL", "http://localhost:8003")
             response = requests.get(f"{ternary_url}/health", timeout=2)
             if response.status_code == 200:
                 data = response.json()
-                return data.get('ternary', False)
+                return data.get("ternary", False)
             return False
-        except:
+        except Exception:
             return False
 
     def estimate_complexity(self, prompt: str) -> Tuple[float, str]:
@@ -170,8 +193,7 @@ class SmartRouter:
         score += keyword_score
 
         # Factor 3: Code detection
-        code_matches = sum(1 for pattern in self.CODE_PATTERNS
-                          if re.search(pattern, prompt))
+        code_matches = sum(1 for pattern in self.CODE_PATTERNS if re.search(pattern, prompt))
         if code_matches >= 2:
             code_score = 0.3
             factors.append("contains code")
@@ -180,10 +202,10 @@ class SmartRouter:
         score += code_score
 
         # Factor 4: Questions vs instructions
-        if '?' in prompt and prompt.count('?') <= 2:
+        if "?" in prompt and prompt.count("?") <= 2:
             question_score = -0.1
             factors.append("simple question")
-        elif 'create' in prompt_lower or 'build' in prompt_lower:
+        elif "create" in prompt_lower or "build" in prompt_lower:
             question_score = 0.2
             factors.append("creative task")
         else:
@@ -201,18 +223,18 @@ class SmartRouter:
         # Ternary-optimized routing (if available)
         if self.ternary_available:
             if complexity < 0.5:
-                return 'bitnet-2b'  # Fast, efficient 2B model
+                return "bitnet-2b"  # Fast, efficient 2B model
             elif complexity < 0.8:
-                return 'mistral-7b-ternary'  # 7B quality, 2.5GB RAM
+                return "mistral-7b-ternary"  # 7B quality, 2.5GB RAM
             else:
-                return 'claude-sonnet'  # Ultra-complex only
+                return "claude-sonnet"  # Ultra-complex only
         # Standard routing (no ternary)
         elif not self.use_local or complexity > 0.6:
-            return 'claude-sonnet'
+            return "claude-sonnet"
         elif complexity < 0.3:
-            return 'tinyllama'
+            return "tinyllama"
         else:
-            return 'phi2'
+            return "phi2"
 
     @staticmethod
     def _count_tokens(text: str) -> int:
@@ -224,13 +246,13 @@ class SmartRouter:
     def estimate_cost(self, prompt: str, model: str, response_length: int = 500) -> float:
         """Estimate cost for request"""
         model_config = self.MODELS.get(model)
-        if not model_config or model_config['backend'] in ('local', 'ternary'):
+        if not model_config or model_config["backend"] in ("local", "ternary"):
             return 0.0
 
         prompt_tokens = self._count_tokens(prompt)
         total_tokens = prompt_tokens + response_length
 
-        cost = total_tokens * model_config['cost_per_token']
+        cost = total_tokens * model_config["cost_per_token"]
         return cost
 
     def route_request(self, prompt: str) -> RoutingDecision:
@@ -253,7 +275,7 @@ class SmartRouter:
             complexity=complexity,
             estimated_cost=cost,
             reasoning=reasoning,
-            backend=model_config['backend']
+            backend=model_config["backend"],
         )
 
         logger.info(f"Routing decision: {model} (complexity: {complexity:.2f}, cost: ${cost:.6f})")
@@ -263,14 +285,10 @@ class SmartRouter:
 
     def execute_ternary_request(self, model: str, prompt: str) -> Dict:
         """Execute request on ternary model server (BitNet)"""
-        ternary_url = os.getenv('TERNARY_URL', 'http://localhost:8003')
+        ternary_url = os.getenv("TERNARY_URL", "http://localhost:8003")
         endpoint = f"{ternary_url}/generate"
 
-        payload = {
-            "model": model,
-            "prompt": prompt,
-            "max_tokens": 512
-        }
+        payload = {"model": model, "prompt": prompt, "max_tokens": 512}
 
         try:
             response = requests.post(endpoint, json=payload, timeout=60)
@@ -278,13 +296,13 @@ class SmartRouter:
             result = response.json()
 
             return {
-                'model': model,
-                'backend': 'ternary',
-                'response': result.get('text', ''),
-                'inference_time_ms': result.get('inference_time_ms', 0),
-                'tokens_per_second': result.get('tokens_per_second', 0),
-                'cost': 0.0,
-                'quantization': '1.58-bit'
+                "model": model,
+                "backend": "ternary",
+                "response": result.get("text", ""),
+                "inference_time_ms": result.get("inference_time_ms", 0),
+                "tokens_per_second": result.get("tokens_per_second", 0),
+                "cost": 0.0,
+                "quantization": "1.58-bit",
             }
         except Exception as e:
             logger.error(f"Ternary request failed: {e}, falling back to cloud")
@@ -293,21 +311,14 @@ class SmartRouter:
 
     def execute_ollama_request(self, model: str, prompt: str) -> Dict:
         """Execute request on local Ollama server"""
-        ollama_url = os.getenv('OLLAMA_URL', 'http://localhost:11434')
+        ollama_url = os.getenv("OLLAMA_URL", "http://localhost:11434")
         endpoint = f"{ollama_url}/api/generate"
 
         # Map our model names to Ollama model names
-        ollama_models = {
-            'tinyllama': 'tinyllama',
-            'phi2': 'phi'
-        }
+        ollama_models = {"tinyllama": "tinyllama", "phi2": "phi"}
         ollama_model = ollama_models.get(model, model)
 
-        payload = {
-            "model": ollama_model,
-            "prompt": prompt,
-            "stream": False
-        }
+        payload = {"model": ollama_model, "prompt": prompt, "stream": False}
 
         try:
             response = requests.post(endpoint, json=payload, timeout=60)
@@ -315,11 +326,11 @@ class SmartRouter:
             result = response.json()
 
             return {
-                'model': model,
-                'backend': 'local',
-                'response': result.get('response', ''),
-                'tokens': result.get('total_duration', 0),
-                'cost': 0.0
+                "model": model,
+                "backend": "local",
+                "response": result.get("response", ""),
+                "tokens": result.get("total_duration", 0),
+                "cost": 0.0,
             }
         except Exception as e:
             logger.error(f"Ollama request failed: {e}")
@@ -332,23 +343,21 @@ class SmartRouter:
 
         try:
             message = self.anthropic_client.messages.create(
-                model=self.claude_model,
-                max_tokens=1024,
-                messages=[{"role": "user", "content": prompt}]
+                model=self.claude_model, max_tokens=1024, messages=[{"role": "user", "content": prompt}]
             )
 
             # Calculate actual cost
             input_tokens = message.usage.input_tokens
             output_tokens = message.usage.output_tokens
-            cost = (input_tokens + output_tokens) * self.MODELS['claude-sonnet']['cost_per_token']
+            cost = (input_tokens + output_tokens) * self.MODELS["claude-sonnet"]["cost_per_token"]
 
             return {
-                'model': 'claude-sonnet',
-                'backend': 'cloud',
-                'response': message.content[0].text,
-                'input_tokens': input_tokens,
-                'output_tokens': output_tokens,
-                'cost': cost
+                "model": "claude-sonnet",
+                "backend": "cloud",
+                "response": message.content[0].text,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cost": cost,
             }
         except Exception as e:
             logger.error(f"Claude request failed: {e}")
@@ -363,18 +372,18 @@ class SmartRouter:
         decision = self.route_request(prompt)
 
         # Execute based on backend
-        if decision.backend == 'ternary':
+        if decision.backend == "ternary":
             result = self.execute_ternary_request(decision.model, prompt)
-        elif decision.backend == 'local':
+        elif decision.backend == "local":
             result = self.execute_ollama_request(decision.model, prompt)
         else:
             result = self.execute_claude_request(prompt)
 
         # Add routing metadata
-        result['routing'] = {
-            'complexity': decision.complexity,
-            'reasoning': decision.reasoning,
-            'estimated_cost': decision.estimated_cost
+        result["routing"] = {
+            "complexity": decision.complexity,
+            "reasoning": decision.reasoning,
+            "estimated_cost": decision.estimated_cost,
         }
 
         # Log to Taskwarrior (if available)
@@ -387,14 +396,18 @@ class SmartRouter:
         if not self.taskwarrior_enabled:
             return
         try:
-            backend_tag = '+ternary' if decision.backend == 'ternary' else '+routing'
+            backend_tag = "+ternary" if decision.backend == "ternary" else "+routing"
             description = f"AI Request: {decision.model}"
             subprocess.run(
                 [
-                    'task', 'add', description,
-                    f'project:vps_ai.router', backend_tag,
+                    "task",
+                    "add",
+                    description,
+                    "project:vps_ai.router",
+                    backend_tag,
                 ],
-                capture_output=True, check=False
+                capture_output=True,
+                check=False,
             )
         except Exception as e:
             logger.debug(f"Taskwarrior logging failed: {e}")
@@ -402,11 +415,7 @@ class SmartRouter:
     def get_stats(self) -> Dict:
         """Get routing statistics (from Taskwarrior)"""
         try:
-            result = subprocess.run(
-                ['task', 'project:vps_ai.router', 'export'],
-                capture_output=True,
-                text=True
-            )
+            result = subprocess.run(["task", "project:vps_ai.router", "export"], capture_output=True, text=True)
 
             if result.returncode == 0 and result.stdout:
                 tasks = json.loads(result.stdout)
@@ -417,37 +426,40 @@ class SmartRouter:
                 ternary_requests = 0
 
                 for t in tasks:
-                    desc = t.get('description', '')
+                    desc = t.get("description", "")
                     if not desc.startswith(prefix):
                         continue
-                    model_name = desc[len(prefix):]
+                    model_name = desc[len(prefix):]  # noqa: E203
                     model_config = self.MODELS.get(model_name)
                     if not model_config:
                         continue
-                    backend = model_config['backend']
-                    if backend == 'local':
+                    backend = model_config["backend"]
+                    if backend == "local":
                         local_requests += 1
-                    elif backend == 'ternary':
+                    elif backend == "ternary":
                         ternary_requests += 1
-                    elif backend == 'cloud':
+                    elif backend == "cloud":
                         cloud_requests += 1
 
                 total_requests = local_requests + cloud_requests + ternary_requests
                 return {
-                    'total_requests': total_requests,
-                    'local_requests': local_requests,
-                    'cloud_requests': cloud_requests,
-                    'ternary_requests': ternary_requests,
-                    'local_percentage': (
-                        (local_requests + ternary_requests) / total_requests * 100
-                    ) if total_requests > 0 else 0,
+                    "total_requests": total_requests,
+                    "local_requests": local_requests,
+                    "cloud_requests": cloud_requests,
+                    "ternary_requests": ternary_requests,
+                    "local_percentage": ((local_requests + ternary_requests) / total_requests * 100)
+                    if total_requests > 0
+                    else 0,
                 }
         except Exception:
             pass
 
         return {
-            'total_requests': 0, 'local_requests': 0, 'cloud_requests': 0,
-            'ternary_requests': 0, 'local_percentage': 0,
+            "total_requests": 0,
+            "local_requests": 0,
+            "cloud_requests": 0,
+            "ternary_requests": 0,
+            "local_percentage": 0,
         }
 
 
@@ -460,7 +472,7 @@ def main():
         print("Example: python smart_router.py 'What is Python?'")
         sys.exit(1)
 
-    prompt = ' '.join(sys.argv[1:])
+    prompt = " ".join(sys.argv[1:])
 
     # Initialize router
     router = SmartRouter()
@@ -469,22 +481,22 @@ def main():
     result = router.process_request(prompt)
 
     # Display results
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Model: {result['model']} ({result['backend']})")
     print(f"Complexity: {result['routing']['complexity']:.2f}")
     print(f"Reasoning: {result['routing']['reasoning']}")
     print(f"Cost: ${result['cost']:.6f}")
-    print(f"{'='*60}\n")
-    print(result['response'])
-    print(f"\n{'='*60}")
+    print(f"{'=' * 60}\n")
+    print(result["response"])
+    print(f"\n{'=' * 60}")
 
     # Show stats
     stats = router.get_stats()
-    print(f"\nRouting Stats:")
+    print("\nRouting Stats:")
     print(f"  Total requests: {stats['total_requests']}")
     print(f"  Local: {stats['local_requests']} ({stats['local_percentage']:.1f}%)")
     print(f"  Cloud: {stats['cloud_requests']}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/smart_router.py
+++ b/scripts/smart_router.py
@@ -429,7 +429,7 @@ class SmartRouter:
                     desc = t.get("description", "")
                     if not desc.startswith(prefix):
                         continue
-                    model_name = desc[len(prefix):]  # noqa: E203
+                    model_name = desc[len(prefix):]
                     model_config = self.MODELS.get(model_name)
                     if not model_config:
                         continue

--- a/scripts/support_router.py
+++ b/scripts/support_router.py
@@ -6,18 +6,19 @@ Demonstrates intelligent routing for customer support queries.
 Simple FAQ-style questions handled locally, complex issues escalated to Claude.
 
 Cost Comparison (10,000 queries/month):
-- Cloud Only:  10,000 × $0.01 avg = $100/month
+- Cloud Only:  10,000 x $0.01 avg = $100/month
 - Hybrid:      7,000 local + 3,000 cloud = $30/month
   Savings: $70/month (70% reduction)
 """
 
 import sys
 import os
-from typing import Dict, List
+from typing import Dict
 
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from smart_router import SmartRouter
+from smart_router import SmartRouter  # noqa: E402
+
 
 class SupportRouter:
     """
@@ -26,30 +27,39 @@ class SupportRouter:
 
     # Common FAQ patterns that can be handled locally
     FAQ_KEYWORDS = [
-        'hours', 'open', 'closed', 'location', 'address',
-        'shipping', 'delivery', 'tracking',
-        'return', 'refund', 'exchange',
-        'password', 'reset', 'login',
-        'price', 'cost', 'discount',
-        'account', 'cancel', 'unsubscribe'
+        "hours",
+        "open",
+        "closed",
+        "location",
+        "address",
+        "shipping",
+        "delivery",
+        "tracking",
+        "return",
+        "refund",
+        "exchange",
+        "password",
+        "reset",
+        "login",
+        "price",
+        "cost",
+        "discount",
+        "account",
+        "cancel",
+        "unsubscribe",
     ]
 
     def __init__(self):
         self.router = SmartRouter()
-        self.stats = {
-            'total_queries': 0,
-            'faq_handled': 0,
-            'escalated': 0,
-            'total_cost': 0.0
-        }
+        self.stats = {"total_queries": 0, "faq_handled": 0, "escalated": 0, "total_cost": 0.0}
 
         # Simple FAQ knowledge base (in production, this would be larger)
         self.faq_db = {
-            'hours': "We're open Monday-Friday 9 AM - 6 PM EST",
-            'shipping': "Standard shipping takes 3-5 business days. Free over $50.",
-            'returns': "30-day return policy. Items must be unused with tags.",
-            'password': "Click 'Forgot Password' on the login page to reset.",
-            'pricing': "Check our pricing page for current rates and discounts."
+            "hours": "We're open Monday-Friday 9 AM - 6 PM EST",
+            "shipping": "Standard shipping takes 3-5 business days. Free over $50.",
+            "returns": "30-day return policy. Items must be unused with tags.",
+            "password": "Click 'Forgot Password' on the login page to reset.",
+            "pricing": "Check our pricing page for current rates and discounts.",
         }
 
     def is_simple_query(self, query: str) -> bool:
@@ -59,7 +69,7 @@ class SupportRouter:
 
     def handle_faq(self, query: str) -> Dict:
         """Handle FAQ using local model"""
-        self.stats['faq_handled'] += 1
+        self.stats["faq_handled"] += 1
 
         # Build context from FAQ database
         faq_context = "\n".join([f"Q: {k} - A: {v}" for k, v in self.faq_db.items()])
@@ -75,19 +85,19 @@ Provide a concise, helpful answer based on the FAQ knowledge base.
 If the question isn't covered, say "I need to escalate this to a specialist."
 """
         # Use Phi-2 for better FAQ handling
-        result = self.router.execute_ollama_request('phi2', prompt)
+        result = self.router.execute_ollama_request("phi2", prompt)
 
         return {
-            'answer': result['response'],
-            'handled_by': 'local_faq',
-            'model': 'phi2',
-            'cost': 0.0,
-            'confidence': 'high' if not 'escalate' in result['response'].lower() else 'low'
+            "answer": result["response"],
+            "handled_by": "local_faq",
+            "model": "phi2",
+            "cost": 0.0,
+            "confidence": "high" if "escalate" not in result["response"].lower() else "low",
         }
 
     def escalate_to_expert(self, query: str, context: str = "") -> Dict:
         """Escalate complex query to Claude"""
-        self.stats['escalated'] += 1
+        self.stats["escalated"] += 1
 
         prompt = f"""You are an expert customer support specialist.
 
@@ -101,37 +111,37 @@ Offer specific solutions or next steps.
 """
         result = self.router.execute_claude_request(prompt)
 
-        self.stats['total_cost'] += result.get('cost', 0)
+        self.stats["total_cost"] += result.get("cost", 0)
 
         return {
-            'answer': result['response'],
-            'handled_by': 'expert_escalation',
-            'model': 'claude-sonnet',
-            'cost': result.get('cost', 0),
-            'confidence': 'expert'
+            "answer": result["response"],
+            "handled_by": "expert_escalation",
+            "model": "claude-sonnet",
+            "cost": result.get("cost", 0),
+            "confidence": "expert",
         }
 
     def process_query(self, query: str) -> Dict:
         """Main query processing pipeline"""
-        self.stats['total_queries'] += 1
+        self.stats["total_queries"] += 1
 
         # Step 1: Check if it's a simple FAQ
         if self.is_simple_query(query):
             result = self.handle_faq(query)
 
             # Check if FAQ handler is confident
-            if result['confidence'] == 'high':
+            if result["confidence"] == "high":
                 return result
             else:
                 # FAQ handler not confident, escalate
-                return self.escalate_to_expert(query, result['answer'])
+                return self.escalate_to_expert(query, result["answer"])
         else:
             # Complex query - go straight to expert
             return self.escalate_to_expert(query)
 
     def get_performance_stats(self) -> Dict:
         """Calculate performance and cost metrics"""
-        total = self.stats['total_queries']
+        total = self.stats["total_queries"]
         if total == 0:
             return {}
 
@@ -139,20 +149,20 @@ Offer specific solutions or next steps.
         cloud_only_cost = total * 0.01  # $0.01 average per query
 
         # Hybrid cost (only escalations)
-        hybrid_cost = self.stats['total_cost']
+        hybrid_cost = self.stats["total_cost"]
 
         savings = cloud_only_cost - hybrid_cost
         savings_pct = (savings / cloud_only_cost * 100) if cloud_only_cost > 0 else 0
 
         return {
-            'total_queries': total,
-            'faq_handled': self.stats['faq_handled'],
-            'escalated': self.stats['escalated'],
-            'faq_percentage': (self.stats['faq_handled'] / total * 100),
-            'cloud_only_cost': cloud_only_cost,
-            'hybrid_cost': hybrid_cost,
-            'savings': savings,
-            'savings_percent': savings_pct
+            "total_queries": total,
+            "faq_handled": self.stats["faq_handled"],
+            "escalated": self.stats["escalated"],
+            "faq_percentage": (self.stats["faq_handled"] / total * 100),
+            "cloud_only_cost": cloud_only_cost,
+            "hybrid_cost": hybrid_cost,
+            "savings": savings,
+            "savings_percent": savings_pct,
         }
 
     def print_summary(self):
@@ -163,18 +173,18 @@ Offer specific solutions or next steps.
             print("No queries processed yet")
             return
 
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("CUSTOMER SUPPORT ROUTER SUMMARY")
-        print("="*60)
+        print("=" * 60)
         print(f"Total Queries: {stats['total_queries']}")
         print(f"   Handled by FAQ (local):  {stats['faq_handled']} ({stats['faq_percentage']:.1f}%)")
-        print(f"   Escalated to Expert:     {stats['escalated']} ({100-stats['faq_percentage']:.1f}%)")
+        print(f"   Escalated to Expert:     {stats['escalated']} ({100 - stats['faq_percentage']:.1f}%)")
         print()
         print("COST COMPARISON:")
         print(f"  Cloud Only:  ${stats['cloud_only_cost']:.4f}")
         print(f"  Hybrid:      ${stats['hybrid_cost']:.4f}")
         print(f"  Savings:     ${stats['savings']:.4f} ({stats['savings_percent']:.1f}%)")
-        print("="*60 + "\n")
+        print("=" * 60 + "\n")
 
 
 def demo():
@@ -195,7 +205,7 @@ def demo():
     ]
 
     print("\nCustomer Support Router Demo")
-    print("="*60)
+    print("=" * 60)
 
     for i, query in enumerate(queries, 1):
         print(f"\n[Query {i}] {query}")
@@ -218,16 +228,16 @@ def demo():
     print("Assuming 70% FAQ, 30% complex:")
     print()
     print("  Cloud Only Approach:")
-    print("    10,000 queries × $0.01 = $100.00/month")
+    print("    10,000 queries x $0.01 = $100.00/month")
     print()
     print("  Hybrid Approach:")
     print("    7,000 FAQ (local) =      $0.00")
     print("    3,000 complex (cloud) = $30.00")
     print("    Total = $30.00/month")
     print()
-    print("  =° Savings: $70.00/month (70% reduction)")
-    print("="*60)
+    print("  = deg Savings: $70.00/month (70% reduction)")
+    print("=" * 60)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     demo()

--- a/scripts/support_router.py
+++ b/scripts/support_router.py
@@ -177,8 +177,8 @@ Offer specific solutions or next steps.
         print("CUSTOMER SUPPORT ROUTER SUMMARY")
         print("=" * 60)
         print(f"Total Queries: {stats['total_queries']}")
-        print(f"   Handled by FAQ (local):  {stats['faq_handled']} ({stats['faq_percentage']:.1f}%)")
-        print(f"   Escalated to Expert:     {stats['escalated']} ({100 - stats['faq_percentage']:.1f}%)")
+        print(f"    Handled by FAQ (local):  {stats['faq_handled']} ({stats['faq_percentage']:.1f}%)")
+        print(f"    Escalated to Expert:     {stats['escalated']} ({100 - stats['faq_percentage']:.1f}%)")
         print()
         print("COST COMPARISON:")
         print(f"  Cloud Only:  ${stats['cloud_only_cost']:.4f}")
@@ -235,7 +235,7 @@ def demo():
     print("    3,000 complex (cloud) = $30.00")
     print("    Total = $30.00/month")
     print()
-    print("  = deg Savings: $70.00/month (70% reduction)")
+    print("  ~ Savings: $70.00/month (70% reduction)")
     print("=" * 60)
 
 

--- a/scripts/ternary_server.py
+++ b/scripts/ternary_server.py
@@ -13,29 +13,27 @@ import logging
 from pathlib import Path
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
 
 # Configuration
-BITNET_PATH = os.getenv('BITNET_PATH', os.path.expanduser("~/ai_stack/bitnet.cpp"))
-MODEL_PATH = os.getenv('MODEL_PATH', os.path.expanduser("~/ai_stack/models/ternary"))
-DEFAULT_MODEL = os.getenv('DEFAULT_MODEL', 'bitnet-2b')
+BITNET_PATH = os.getenv("BITNET_PATH", os.path.expanduser("~/ai_stack/bitnet.cpp"))
+MODEL_PATH = os.getenv("MODEL_PATH", os.path.expanduser("~/ai_stack/models/ternary"))
+DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "bitnet-2b")
 
 # Model mapping
 MODELS = {
-    'bitnet-2b': 'bitnet-2b/ggml-model-i2_s.gguf',
-    'mistral-7b-ternary': 'falcon3-7b/ggml-model-i2_s.gguf',  # Falcon3 as Mistral alternative
-    'llama-8b-ternary': 'llama3-8b-ternary/ggml-model-i2_s.gguf',
-    'falcon3-7b': 'falcon3-7b/ggml-model-i2_s.gguf',
-    'falcon3-3b': 'falcon3-3b/ggml-model-i2_s.gguf',
+    "bitnet-2b": "bitnet-2b/ggml-model-i2_s.gguf",
+    "mistral-7b-ternary": "falcon3-7b/ggml-model-i2_s.gguf",  # Falcon3 as Mistral alternative
+    "llama-8b-ternary": "llama3-8b-ternary/ggml-model-i2_s.gguf",
+    "falcon3-7b": "falcon3-7b/ggml-model-i2_s.gguf",
+    "falcon3-3b": "falcon3-3b/ggml-model-i2_s.gguf",
 }
 
-@app.route('/health', methods=['GET'])
+
+@app.route("/health", methods=["GET"])
 def health():
     """Health check endpoint"""
     models_available = []
@@ -45,23 +43,26 @@ def health():
         if full_path.exists():
             models_available.append(model_key)
 
-    return jsonify({
-        "status": "healthy",
-        "ternary": True,
-        "framework": "BitNet.cpp",
-        "models_available": models_available,
-        "bitnet_path": BITNET_PATH,
-        "model_path": MODEL_PATH
-    })
+    return jsonify(
+        {
+            "status": "healthy",
+            "ternary": True,
+            "framework": "BitNet.cpp",
+            "models_available": models_available,
+            "bitnet_path": BITNET_PATH,
+            "model_path": MODEL_PATH,
+        }
+    )
 
-@app.route('/generate', methods=['POST'])
+
+@app.route("/generate", methods=["POST"])
 def generate():
     """Generate text using ternary model"""
     data = request.json
-    prompt = data.get('prompt', '')
-    model = data.get('model', DEFAULT_MODEL)
-    max_tokens = data.get('max_tokens', 512)
-    temperature = data.get('temperature', 0.7)
+    prompt = data.get("prompt", "")
+    model = data.get("model", DEFAULT_MODEL)
+    max_tokens = data.get("max_tokens", 512)
+    temperature = data.get("temperature", 0.7)
 
     if not prompt:
         return jsonify({"error": "No prompt provided"}), 400
@@ -74,11 +75,13 @@ def generate():
     model_file = Path(MODEL_PATH) / MODELS[model]
 
     if not model_file.exists():
-        return jsonify({
-            "error": f"Model not found: {model}",
-            "path": str(model_file),
-            "available_models": [k for k, v in MODELS.items() if (Path(MODEL_PATH) / v).exists()]
-        }), 404
+        return jsonify(
+            {
+                "error": f"Model not found: {model}",
+                "path": str(model_file),
+                "available_models": [k for k, v in MODELS.items() if (Path(MODEL_PATH) / v).exists()],
+            }
+        ), 404
 
     logger.info(f"Generating with model: {model}, prompt length: {len(prompt)} chars")
 
@@ -98,31 +101,25 @@ def generate():
         cmd = [
             str(venv_python),
             str(inference_script),
-            "-m", str(model_file),
-            "-p", prompt,
-            "-n", str(max_tokens),
-            "-t", str(temperature)
+            "-m",
+            str(model_file),
+            "-p",
+            prompt,
+            "-n",
+            str(max_tokens),
+            "-t",
+            str(temperature),
         ]
 
         logger.debug(f"Running command: {' '.join(cmd)}")
 
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=60,
-            cwd=BITNET_PATH
-        )
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60, cwd=BITNET_PATH)
 
         inference_time = (time.time() - start_time) * 1000
 
         if result.returncode != 0:
             logger.error(f"Inference failed: {result.stderr}")
-            return jsonify({
-                "error": "Inference failed",
-                "stderr": result.stderr,
-                "stdout": result.stdout
-            }), 500
+            return jsonify({"error": "Inference failed", "stderr": result.stderr, "stdout": result.stdout}), 500
 
         # Parse output
         response_text = result.stdout.strip()
@@ -132,16 +129,18 @@ def generate():
 
         logger.info(f"Inference completed: {inference_time:.2f}ms, {tokens_per_second:.1f} tok/s")
 
-        return jsonify({
-            "text": response_text,
-            "model": model,
-            "inference_time_ms": inference_time,
-            "tokens_per_second": tokens_per_second,
-            "prompt_tokens": len(prompt.split()),
-            "completion_tokens": max_tokens,
-            "backend": "ternary",
-            "quantization": "1.58-bit"
-        })
+        return jsonify(
+            {
+                "text": response_text,
+                "model": model,
+                "inference_time_ms": inference_time,
+                "tokens_per_second": tokens_per_second,
+                "prompt_tokens": len(prompt.split()),
+                "completion_tokens": max_tokens,
+                "backend": "ternary",
+                "quantization": "1.58-bit",
+            }
+        )
 
     except subprocess.TimeoutExpired:
         logger.error("Inference timeout")
@@ -150,7 +149,8 @@ def generate():
         logger.error(f"Inference error: {str(e)}")
         return jsonify({"error": str(e)}), 500
 
-@app.route('/models', methods=['GET'])
+
+@app.route("/models", methods=["GET"])
 def list_models():
     """List available models"""
     available = []
@@ -159,19 +159,14 @@ def list_models():
         full_path = Path(MODEL_PATH) / model_path
         if full_path.exists():
             size_mb = full_path.stat().st_size / (1024 * 1024)
-            available.append({
-                "name": model_key,
-                "path": model_path,
-                "size_mb": round(size_mb, 2),
-                "quantization": "1.58-bit"
-            })
+            available.append(
+                {"name": model_key, "path": model_path, "size_mb": round(size_mb, 2), "quantization": "1.58-bit"}
+            )
 
-    return jsonify({
-        "models": available,
-        "count": len(available)
-    })
+    return jsonify({"models": available, "count": len(available)})
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     # Verify BitNet installation
     if not Path(BITNET_PATH).exists():
         logger.error(f"BitNet not found at {BITNET_PATH}")
@@ -182,9 +177,9 @@ if __name__ == '__main__':
         logger.warning(f"Model directory not found: {MODEL_PATH}")
         logger.warning("Run ./scripts/download_ternary_models.sh to download models")
 
-    logger.info(f"Starting Ternary Model Server")
+    logger.info("Starting Ternary Model Server")
     logger.info(f"BitNet path: {BITNET_PATH}")
     logger.info(f"Model path: {MODEL_PATH}")
 
     # Start Flask server
-    app.run(host='0.0.0.0', port=8003, debug=False)
+    app.run(host="0.0.0.0", port=8003, debug=False)


### PR DESCRIPTION
## Summary

Fixes `OPS-1jh` — pre-existing CI `lint` failures on `main` since 2026-03-25 (`flake8 scripts/ gateway/ --max-line-length=120` reported 31 violations).

- Ran `ruff format scripts/ gateway/ --line-length 120` to auto-resolve 21 issues (E302/E305 blank lines, F401 unused imports)
- Manually addressed the remaining 10 with surgical fixes or targeted `# noqa` comments documented in the commit message
- Fixed two files containing stray Latin-1 multiplication sign bytes (0xd7) that blocked ruff from processing them — replaced with ASCII `x`
- Added `.beads/.beads-credential-key` to `.beads/.gitignore` (gap in bd's default ignore — credential file is machine-local bd auth material and must never be committed)

`flake8 scripts/ gateway/ --max-line-length=120` now exits 0.

## Test plan

- [x] `flake8 scripts/ gateway/ --max-line-length=120` exits clean (verified locally)
- [x] `pytest tests/ -v` passes all 54 tests (no behavior change)
- [x] `python3 -c "import sys; sys.path.insert(0, 'scripts'); import smart_router"` works (E402 noqa preserves the sys.path-then-import pattern)
- [ ] CI green on PR

Refs OPS-1jh

- Jeremy Longshore
intentsolutions.io